### PR TITLE
Merging two lines when announcing users who have not logged their hours

### DIFF
--- a/redmineXMPPbot.py
+++ b/redmineXMPPbot.py
@@ -101,10 +101,9 @@ def main():
 	
     if lateUsers:
 	bot.join_room(chatroom, 'credilbot')
-	announce('The following users have not logged time within their set threshold (default '+ str(thresholdDefault) +')')
-	announce(', '.join(lateUsers)) 
-        
- 
+	announce(', '.join(lateUsers) + ' have not logged time within their set threshold (default '+ str(thresholdDefault) +')')
+
+
 if __name__ == "__main__":
     main()
 


### PR DESCRIPTION
Previously, we had: 

<pre>
15-04-15 02:05:34 PM) credilbot: The following users have not logged time within their set threshold (default 4)
(15-04-15 02:05:35 PM) credilbot: td, jjrh, crm, mcr, amisaka
</pre>


We should  now have:

<pre>
(15-04-15 02:05:35 PM) credilbot: td, jjrh, crm, mcr, amisaka have not logged time within their set threshold (default 4)
</pre>
